### PR TITLE
Ask GitHub for closed PRs not recently updated PRs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,7 @@ private_lane :merged_prs_since_last_beta_release do |options|
     server_url: "https://api.github.com",
     api_token: github_token,
     http_method: "GET",
-    path: "/repos/guardian/#{repo}/pulls?state=closed&base=master&sort=updated&direction=desc"
+    path: "/repos/guardian/#{repo}/pulls?state=closed&base=master&sort=closed&direction=desc"
   )
   recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
   merged_prs_since_last_beta = closed_prs[:json].reject{ |pr|


### PR DESCRIPTION
We were sorting on the wrong value when querying GitHub. 

This has been working fine until now (by luck, not design), since merging is normally one of the last updates that a PR receives. However, this morning a lot of old branches were tidied up, meaning that many very old PRs had a much more recent update timestamp. This meant that the first X PRs returned by the GitHub API were merged _well before_ the [specified cut off date](https://github.com/guardian/cross-platform-fastlane/blob/master/fastlane/Fastfile#L29). Consequently an empty changelog was produced.