### PR TITLE
Add lane which allows us to add tags using the GitHub API

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,7 +80,7 @@ private_lane :add_tag do |options|
   commit_sha = options[:commit_sha]
   tag_name = options[:tag_name]
 
-  UI.message("Adding tag #{tag_name} to #{repo} repo")
+  UI.message("Adding tag #{tag_name} to commit #{commit_sha} for the #{repo} repo...")
   github_api(
     server_url: "https://api.github.com",
     api_token: github_token,
@@ -88,8 +88,8 @@ private_lane :add_tag do |options|
     path: "/repos/guardian/#{repo}/git/refs",
     body: { "ref": "refs/tags/#{tag_name}", "sha": "#{commit_sha}" }
   )
-  
-end  
+
+end
 
 private_lane :find_included_templates_versions do
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,3 +61,21 @@ private_lane :update_pr_after_beta_release do |options|
   )
 
 end
+
+private_lane :add_tag do |options|
+
+  repo = options[:repo]
+  github_token = options[:github_token]
+  commit_sha = options[:commit_sha]
+  tag_name = options[:tag_name]
+
+  UI.message("Adding tag #{tag_name} to #{repo} repo")
+  github_api(
+    server_url: "https://api.github.com",
+    api_token: github_token,
+    http_method: "POST",
+    path: "/repos/guardian/#{repo}/git/refs",
+    body: { "ref": "refs/tags/#{tag_name}", "sha": "#{commit_sha}" }
+  )
+
+end


### PR DESCRIPTION
We currently use [a TeamCity build feature](https://www.jetbrains.com/help/teamcity/vcs-labeling.html#VCSLabeling-AutomaticVCSlabeling) to tag our releases. There are a few reasons I'd prefer to move away from this approach and add tags as part of our `fastlane` scripts:

1. There have been a few occasions where the tagging has not worked and we've failed to notice. Moving this logic into the release script should make it easier to spot failures. 
1. Using the TeamCity feature means that our tagging setup is configured via the TeamCity UI, rather than being tracked via `git`, which makes configuration errors harder to spot.
1. Using the TeamCity feature means that we're closely tied to TeamCity (obviously), which makes it harder to migrate (or experiment with) other CI systems/tools. 
1. We are slowly moving all release-related automation into `fastlane` - moving the tagging here too helps to make things consistent.

This PR adds functionality for tagging to the shared Fastfile (which is already imported by the iOS and Android Live apps). Once this is merged we'll be able to add tags as part of the release (or post-release) script.