### PR TITLE
Add new lane for collecting release notes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,9 +31,9 @@ private_lane :merged_prs_since_last_release do |options|
     pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
   }
 
-  PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at)
+  PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
   all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
-    PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"])
+    PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
   }
 
   result = if ensure_git_log_includes_pr
@@ -43,6 +43,29 @@ private_lane :merged_prs_since_last_release do |options|
     }
   else
     all_prs_since_last_labelling
+  end
+
+end
+
+private_lane :prepare_release_notes do |options|
+
+  prs = options[:prs]
+  optional_preamble = options[:preamble]
+  optional_postamble = options[:postamble] # Yes, it is a real word
+
+  release_notes = prs.map { |pr|
+    pr.body
+      .split("<!--beta_release_notes_start-->").last
+      .split("<!--beta_release_notes_end-->").first
+      .strip
+  }
+
+  release_note_bullets = release_notes.map{ |release_note_line| "* #{release_note_line}" }.join("\n")
+
+  if release_note_bullets.empty?
+    "Please use the app as you normally would and let us know if you spot any problems."
+  else
+    "#{optional_preamble}\n#{release_note_bullets}\n#{optional_postamble}"
   end
 
 end


### PR DESCRIPTION
## Why are we doing this?

We want to upload meaningful release notes for all beta releases to improve beta tester engagement and ensure we collect as much useful feedback as possible.

Currently, release notes are (occasionally) added manually _after a beta release_ has been uploaded. This is problematic because:

1. It is hard for a single individual to summarise a list of changes when they may not be familiar with all of them.
1. It is not clear who should take the responsibility for adding release notes.

As a result, detailed release notes for betas are only added on very rare occasions.

## How does this new lane work?

We already have (and use) [functionality](https://github.com/guardian/cross-platform-fastlane/blob/master/fastlane/Fastfile#L12-L48) to determine which merged PRs have been included in a particular release. 

Since we already have a list of pull requests, this lane provides new functionality for extracting release notes from pull request bodies, when they are provided in the following format:

```
<!--beta_release_notes_start-->
We've added the letter 'b' to our README.md
<!--beta_release_notes_end-->
```

## How will we use it?

#### 1. Add the following section to our PR template:

```
#### Information for beta release notes: <!-- Delete if not applicable -->

<!-- 
Any text between the 'beta_release_notes_start' and 'beta_release_notes_end' tags will be included in the release notes which we upload to TestFlight / the Play Store. If your change will have a noticeable impact for users, please try to briefly describe it here.

Guidance:
The text will be added to a list of bullet points (the formatting happens automatically), so please keep your message on a single line. Please use past tense to retain consistency across release notes. 

Examples: 
1. We've added a new feature which allows you to subscribe to notifications about the General Election
2. Fixed a bug which prevented some users from posting comments
-->

<!--beta_release_notes_start-->
<!--beta_release_notes_end-->
```
Suggestions on the wording/conventions used are welcome when I raise the PR to update the relevant templates!

#### 2. PR authors start to update the release notes section when raising PRs (if relevant). 

Reviewers can also suggest (or make) changes to the release notes description as part of the review process if they deem it to be appropriate.

This solves the problems mentioned in the `Why are we doing this?` section, because everybody should be able describe the impact of _their own_ changes (or the changes they are reviewing). It also shares the responsibility for adding release notes evenly amongst the team without adding much work for anybody.

#### 3. We'll call this new lane from our `Fastfile`, so that release notes are produced whenever a beta build is released:

```
merged_prs = merged_prs_since_last_release(
    ...
)

release_notes = prepare_release_notes(
    prs: merged_prs,
    preamble: "We've been busy preparing for the General Election and fixing bugs! Here are some more details:",
    postamble: "To report a bug without leaving the app, simply shake your device to reveal the bug icon."
)
```
Here's some example output from a [simple repo](https://github.com/jacobwinch/post-release-testing/pulls?q=is%3Apr+is%3Aclosed) that I set up for testing purposes:

```
We've been busy preparing for the General Election and fixing bugs! Here are some more details:
* We've added the letter 'b' to our README.md
* We've added the letter 'a' to our README.md
To report a bug without leaving the app, simply shake your device to reveal the bug icon.
```

#### 4a. Post the changes into Google Chat

Initially, I plan to post the user-facing release notes into Google Chat, along with the list of PRs (until we are confident that we consistently produce sensible release notes). 

#### 4b. Push release notes to the stores

Once we've reached some level of confidence, we'll automatically push the release notes to the relevant store when we upload the build.

This functionality is already provided by `fastlane` for [Android](https://docs.fastlane.tools/actions/supply/#changelogs-whats-new) and [iOS](https://github.com/guardian/ios-live/blob/master/GLA/fastlane/Fastfile#L45).