### PR TITLE
Fix bugs with release note collection

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,6 +53,7 @@ private_lane :prepare_release_notes do |options|
   optional_preamble = options[:preamble]
   optional_postamble = options[:postamble] # Yes, it is a real word
 
+  # Discard any PR which omits the release_notes tags
   prs_with_release_notes = prs.select { |pr|
     pr.body.include?("<!--beta_release_notes_start-->") && pr.body.include?("<!--beta_release_notes_end-->")
   }
@@ -65,6 +66,7 @@ private_lane :prepare_release_notes do |options|
   }
 
   release_note_bullets = release_notes
+    .reject { |release_note_line| release_note_line.empty? } # Discard any blank release note messages
     .map{ |release_note_line| "* #{release_note_line}" }.join("\n")
 
   if release_note_bullets.empty?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,14 +53,19 @@ private_lane :prepare_release_notes do |options|
   optional_preamble = options[:preamble]
   optional_postamble = options[:postamble] # Yes, it is a real word
 
-  release_notes = prs.map { |pr|
+  prs_with_release_notes = prs.select { |pr|
+    pr.body.include?("<!--beta_release_notes_start-->") && pr.body.include?("<!--beta_release_notes_end-->")
+  }
+
+  release_notes = prs_with_release_notes.map { |pr|
     pr.body
       .split("<!--beta_release_notes_start-->").last
       .split("<!--beta_release_notes_end-->").first
       .strip
   }
 
-  release_note_bullets = release_notes.map{ |release_note_line| "* #{release_note_line}" }.join("\n")
+  release_note_bullets = release_notes
+    .map{ |release_note_line| "* #{release_note_line}" }.join("\n")
 
   if release_note_bullets.empty?
     "Please use the app as you normally would and let us know if you spot any problems."


### PR DESCRIPTION
This PR https://github.com/guardian/cross-platform-fastlane/pull/7 has the following problems:

* It will select text that we do not want if the `<!--beta_release_notes_start-->` and/or `<!--beta_release_notes_end-->` tags are missing.
* It will produce an empty bullet `*` if the tags have been left in the template but the release note section has not been filled in.