### PR TITLE
Ask GitHub for more PRs when searching PR history

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ private_lane :merged_prs_since_last_release do |options|
     server_url: "https://api.github.com",
     api_token: github_token,
     http_method: "GET",
-    path: "/repos/guardian/#{repo}/pulls?state=created&base=master&sort=closed&direction=desc&per_page=100"
+    path: "/repos/guardian/#{repo}/pulls?state=closed&base=master&sort=created&direction=desc&per_page=100"
   )
 
   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ private_lane :merged_prs_since_last_release do |options|
     server_url: "https://api.github.com",
     api_token: github_token,
     http_method: "GET",
-    path: "/repos/guardian/#{repo}/pulls?state=closed&base=master&sort=closed&direction=desc"
+    path: "/repos/guardian/#{repo}/pulls?state=closed&base=master&sort=closed&direction=desc&per_page=100"
   )
 
   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ private_lane :merged_prs_since_last_release do |options|
     server_url: "https://api.github.com",
     api_token: github_token,
     http_method: "GET",
-    path: "/repos/guardian/#{repo}/pulls?state=closed&base=master&sort=closed&direction=desc&per_page=100"
+    path: "/repos/guardian/#{repo}/pulls?state=created&base=master&sort=closed&direction=desc&per_page=100"
   )
 
   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|


### PR DESCRIPTION
@jordanterry reported that one of his recently merged [changes](https://github.com/guardian/android-news-app/pull/5742) was omitted from the changelog. 

It seems that long-running PRs are not being picked up correctly. Unfortunately the change added by https://github.com/guardian/cross-platform-fastlane/pull/3 is no longer working as [sorting based on closed PRs is not currently supported](https://developer.github.com/v3/pulls/#parameters). Presumably this means the response we receive is sorted on `created`, as this is the default. 

This change is a simple way to pick up longer running PRs (we will now get the 100 most recently created PRs; by default GitHub's API was only returning 30 PRs). If we want more history we will have to deal with [pagination](https://developer.github.com/v3/guides/traversing-with-pagination/#basics-of-pagination) and I'd rather avoid that if possible (since each HTTP request increases the risk of the script failing) - I think this 'fix' should be sufficient for most normal cases.

I've tested this by running locally and confirming that https://github.com/guardian/android-news-app/pull/5742 was picked up by the post-release automation.