### PR TITLE
Add lane for extracting release notes as an array 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,11 +47,9 @@ private_lane :merged_prs_since_last_release do |options|
 
 end
 
-private_lane :prepare_release_notes do |options|
+private_lane :extract_release_notes do |options|
 
   prs = options[:prs]
-  optional_preamble = options[:preamble]
-  optional_postamble = options[:postamble] # Yes, it is a real word
 
   # Discard any PR which omits the release_notes tags
   prs_with_release_notes = prs.select { |pr|
@@ -65,9 +63,17 @@ private_lane :prepare_release_notes do |options|
       .strip
   }
 
-  release_note_bullets = release_notes
-    .reject { |release_note_line| release_note_line.empty? } # Discard any blank release note messages
-    .map{ |release_note_line| "* #{release_note_line}" }.join("\n")
+  release_notes.reject { |release_note_line| release_note_line.empty? } # Discard any blank release note messages
+
+end
+
+private_lane :prepare_release_notes do |options|
+
+  prs = options[:prs]
+  optional_preamble = options[:preamble]
+  optional_postamble = options[:postamble] # Yes, it is a real word
+
+  release_note_bullets = extract_release_notes(prs).map{ |release_note_line| "* #{release_note_line}" }.join("\n")
 
   if release_note_bullets.empty?
     "Please use the app as you normally would and let us know if you spot any problems."

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,7 +73,7 @@ private_lane :prepare_release_notes do |options|
   optional_preamble = options[:preamble]
   optional_postamble = options[:postamble] # Yes, it is a real word
 
-  release_note_bullets = extract_release_notes(prs).map{ |release_note_line| "* #{release_note_line}" }.join("\n")
+  release_note_bullets = extract_release_notes(prs: prs).map{ |release_note_line| "* #{release_note_line}" }.join("\n")
 
   if release_note_bullets.empty?
     "Please use the app as you normally would and let us know if you spot any problems."


### PR DESCRIPTION
`prepare_release_notes` formats release notes for the stores.

However, we'd also like to make the release notes available in a raw form so that they can be used for other things (e.g. consumed via an API). This PR adds that functionality.