### PR TITLE
Add environment to release notes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -86,7 +86,7 @@ private_lane :prepare_release_notes do |options|
   release_note_bullets = extract_release_notes(environment: environment, prs: prs).map{ |release_note_line| "* #{release_note_line}" }.join("\n")
 
   if release_note_bullets.empty?
-    "Please use the app as you normally would and let us know if you spot any problems."
+    "We've been fixing bugs and making improvements behind the scenes. For the best possible experience and to ensure you have access to all our latest features we recommend that you update to this latest version as soon as possible."
   else
     "#{optional_preamble}\n#{release_note_bullets}\n#{optional_postamble}"
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,7 +49,12 @@ end
 
 private_lane :extract_release_notes do |options|
 
-  environment = options[:environment]
+  if options[:environment].to_s == ""
+    environment = "beta"
+  else
+    environment = options[:environment]
+  end
+
   prs = options[:prs]
 
   regex_start = "<!--#{environment}_release_notes_start-->"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,17 +49,21 @@ end
 
 private_lane :extract_release_notes do |options|
 
+  environment = options[:environment]
   prs = options[:prs]
+
+  regex_start = "<!--#{environment}_release_notes_start-->"
+  regex_end = "<!--#{environment}_release_notes_end-->"
 
   # Discard any PR which omits the release_notes tags
   prs_with_release_notes = prs.select { |pr|
-    pr.body.include?("<!--beta_release_notes_start-->") && pr.body.include?("<!--beta_release_notes_end-->")
+    pr.body.include?(regex_start) && pr.body.include?(regex_end)
   }
 
   release_notes = prs_with_release_notes.map { |pr|
     pr.body
-      .split("<!--beta_release_notes_start-->").last
-      .split("<!--beta_release_notes_end-->").first
+      .split(regex_start).last
+      .split(regex_end).first
       .strip
   }
 
@@ -69,11 +73,12 @@ end
 
 private_lane :prepare_release_notes do |options|
 
+  environment = options[:environment]
   prs = options[:prs]
   optional_preamble = options[:preamble]
   optional_postamble = options[:postamble] # Yes, it is a real word
 
-  release_note_bullets = extract_release_notes(prs: prs).map{ |release_note_line| "* #{release_note_line}" }.join("\n")
+  release_note_bullets = extract_release_notes(environment: environment, prs: prs).map{ |release_note_line| "* #{release_note_line}" }.join("\n")
 
   if release_note_bullets.empty?
     "Please use the app as you normally would and let us know if you spot any problems."


### PR DESCRIPTION
Allows us to automatically generate release notes for beta and production environments.
