### PR TITLE
Add environment agnostic PR update lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -93,6 +93,34 @@ private_lane :prepare_release_notes do |options|
 
 end
 
+private_lane :update_pr_after_release do |options|
+
+  repo = options[:repo]
+  github_token = options[:github_token]
+  pr_number = options[:pr_number]
+  pr_author = options[:pr_author]
+  full_version = options[:full_version]
+  environment = options[:environment]
+
+  UI.message("Marking PR #{pr_number} as released to #{environment}")
+  github_api(
+    server_url: "https://api.github.com",
+    api_token: github_token,
+    http_method: "POST",
+    path: "/repos/guardian/#{repo}/issues/#{pr_number}/labels",
+    body: { labels: ["released_to_#{environment}"] }
+  )
+  github_api(
+    server_url: "https://api.github.com",
+    api_token: github_token,
+    http_method: "POST",
+    path: "/repos/guardian/#{repo}/issues/#{pr_number}/comments",
+    body: { body: "@#{pr_author}: these changes were released to #{environment} in version `#{full_version}`." }
+  )
+
+end
+
+# This can be deleted in a couple of weeks, once everyone has stopped using it
 private_lane :update_pr_after_beta_release do |options|
 
   repo = options[:repo]


### PR DESCRIPTION
The [existing functionality ](https://github.com/guardian/cross-platform-fastlane/blob/b8fbea62819a20f932527b24f21dbfe2edbb21c2/fastlane/Fastfile#L96-L120) for adding labels/PR comments is tightly coupled to beta releases. I've added a new [`lane`](https://docs.fastlane.tools/advanced/lanes/) which is agnostic about the environment. This will enable us to track which changes have been released to production.

Once all apps which use this library have migrated over to the new `lane` I'll remove `update_pr_after_beta_release`, which is essentially deprecated in favour of this.