### PR TITLE
Add support for both 'main' and 'master as base branches

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,13 +17,13 @@ private_lane :merged_prs_since_last_release do |options|
   earliest_datetime = options[:earliest_datetime]
   ensure_git_log_includes_pr = options[:ensure_git_log_includes_pr]
   
-  base_branch_name = if repo == "android-news-app"
-    "main"
+  base_branch_name = if options.has_key?(:base_branch_name)
+    options[:base_branch_name]
   else
     "master"
   end
 
-
+  
   # Find all PRs that have been merged to master since the last beta went out
   closed_prs = github_api(
     server_url: "https://api.github.com",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,13 +16,20 @@ private_lane :merged_prs_since_last_release do |options|
   github_label = options[:github_label]
   earliest_datetime = options[:earliest_datetime]
   ensure_git_log_includes_pr = options[:ensure_git_log_includes_pr]
+  
+  base_branch_name = if repo == "android-news-app"
+    "main"
+  else
+    "master"
+  end
+
 
   # Find all PRs that have been merged to master since the last beta went out
   closed_prs = github_api(
     server_url: "https://api.github.com",
     api_token: github_token,
     http_method: "GET",
-    path: "/repos/guardian/#{repo}/pulls?state=closed&base=master&sort=created&direction=desc&per_page=100"
+    path: "/repos/guardian/#{repo}/pulls?state=closed&base=#{base_branch_name}&sort=created&direction=desc&per_page=100"
   )
 
   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|


### PR DESCRIPTION
## What does this change?

If the call to `merged_prs_since_last_release` provides a `base_branch_name`, we use that as base to fetch closed PRs. If no name is provided, we use `master` as the base branch.

1. Introduced a new variable `base_branch_name` in lane `merged_prs_since_last_release`. 
2. Introduced a new optional property, `base_branch_name` to the `options` argument for `merged_prs_since_last_release`.

## How can we measure success?

1. Merged PRs list populates for bot updates about Android beta releases.
2. Merged PRs list continues to populate for bot updates about iOS beta releases.
