### PR TITLE
Remove `ensure_git_log_includes_pr` option

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,7 +15,6 @@ private_lane :merged_prs_since_last_release do |options|
   github_token = options[:github_token]
   github_label = options[:github_label]
   earliest_datetime = options[:earliest_datetime]
-  ensure_git_log_includes_pr = options[:ensure_git_log_includes_pr]
   
   base_branch_name = if options.has_key?(:base_branch_name)
     options[:base_branch_name]
@@ -43,14 +42,11 @@ private_lane :merged_prs_since_last_release do |options|
     PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
   }
 
-  result = if ensure_git_log_includes_pr
-    all_prs_since_last_labelling.reject { |pr|
-      recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
-      !recent_commits.include?(pr.merge_sha)
-    }
-  else
-    all_prs_since_last_labelling
-  end
+  # Only include PRs that actually made it into the git history (see https://github.com/guardian/android-news-app/pull/5339)
+  all_prs_since_last_labelling.reject { |pr|
+    recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
+    !recent_commits.include?(pr.merge_sha)
+  }
 
 end
 


### PR DESCRIPTION
## What does this change?
Removes the `ensure_git_log_includes_pr` option, in favour of it always being true. Since [the only uses of this lane]( ensure_git_log_includes_pr) both use this as true, this will have no real-world effect, but reduce the amount of code.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Check that the release notes/PR logs of the next few builds on each platform are sensible. You can also see https://github.com/guardian/ios-live/actions/workflows/sl-test.yml for a test workflow that calls this.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Everything works as before

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
A third party could be using this cross-platform repo, and want the opposite behaviour.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
N/A