### PR TITLE
LIVE-1763: Fix release notes when creating from a tag/non-default branch

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,6 +24,7 @@ private_lane :merged_prs_since_last_release do |options|
   end
 
   # Find all PRs that have been merged since the last beta went out
+  # Don't use `sort=updated` here, because some changes (e.g. branch names, labelling) may mass-update very old PRs.
   closed_prs = github_api(
     server_url: "https://api.github.com",
     api_token: github_token,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,7 @@ private_lane :merged_prs_since_last_release do |options|
   end
 
   
-  # Find all PRs that have been merged to master since the last beta went out
+  # Find all PRs that have been merged to the base branch since the last beta went out
   closed_prs = github_api(
     server_url: "https://api.github.com",
     api_token: github_token,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,12 +45,12 @@ private_lane :merged_prs_since_last_release do |options|
 
   result = if ensure_git_log_includes_pr
     current_branch = sh("git branch --show-current")
-    sh("git checkout %f" % base_branch_name)
+    sh("git checkout %s" % base_branch_name)
     all_prs_since_last_labelling.reject { |pr|
       recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
       !recent_commits.include?(pr.merge_sha)
     }
-    sh("git checkout %f" % current_branch)
+    sh("git checkout %s" % current_branch)
   else
     all_prs_since_last_labelling
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,12 +23,12 @@ private_lane :merged_prs_since_last_release do |options|
     "master"
   end
 
-  # Find all PRs that have been merged to the base branch since the last beta went out
+  # Find all PRs that have been merged since the last beta went out
   closed_prs = github_api(
     server_url: "https://api.github.com",
     api_token: github_token,
     http_method: "GET",
-    path: "/repos/guardian/#{repo}/pulls?state=closed&base=#{base_branch_name}&sort=created&direction=desc&per_page=100"
+    path: "/repos/guardian/#{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
   )
 
   UI.message("Closed PRs:\n#{closed_prs}")
@@ -39,16 +39,21 @@ private_lane :merged_prs_since_last_release do |options|
     pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
   }
 
+  UI.message("Merged PRs:\n#{merged_prs_since_last_labelling}")
+
   PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
   all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
     PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
   }
 
+  UI.message("All PRs:\n#{all_prs_since_last_labelling}")
+
+  #TODO: This should be the default. Why would you ever want the opposite?
   result = if ensure_git_log_includes_pr
     current_branch = sh("git branch --show-current")
     sh("git fetch")
     sh("git checkout %s" % base_branch_name)
-    recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
+    recent_commits = sh("git log --format=\"%H\" -100").split("\n")
     sh("git checkout %s" % current_branch)
 
     all_prs_since_last_labelling.reject { |pr|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,24 +31,17 @@ private_lane :merged_prs_since_last_release do |options|
     path: "/repos/guardian/#{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
   )
 
-  UI.message("Closed PRs:\n#{closed_prs[:json].length()}")
-
   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|
     pr["merged_at"].nil? || # Pull request was never merged
     DateTime.parse(pr["merged_at"]) < DateTime.parse(earliest_datetime) || # Pull request was merged before the earliest date provided
     pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
   }
 
-  UI.message("Merged PRs length:\n#{merged_prs_since_last_labelling.length()}")
-
   PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
   all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
     PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
   }
 
-  UI.message("All PRs length:\n#{all_prs_since_last_labelling.length()}")
-
-  #TODO: This should be the default. Why would you ever want the opposite?
   result = if ensure_git_log_includes_pr
     current_branch = sh("git branch --show-current")
     sh("git fetch")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,10 +44,13 @@ private_lane :merged_prs_since_last_release do |options|
   }
 
   result = if ensure_git_log_includes_pr
+    current_branch = sh("git branch --show-current")
+    sh("git checkout base_branch_name")
     all_prs_since_last_labelling.reject { |pr|
       recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
       !recent_commits.include?(pr.merge_sha)
     }
+    sh("git checkout %f" % current_branch)
   else
     all_prs_since_last_labelling
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,13 +45,14 @@ private_lane :merged_prs_since_last_release do |options|
 
   result = if ensure_git_log_includes_pr
     current_branch = sh("git branch --show-current")
-    sh("git fetch")
+    sh("git fetch origin %s" % base_branch_name)
     sh("git checkout %s" % base_branch_name)
+    recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
+    sh("git checkout %s" % current_branch)
+
     all_prs_since_last_labelling.reject { |pr|
-      recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
       !recent_commits.include?(pr.merge_sha)
     }
-    sh("git checkout %s" % current_branch)
   else
     all_prs_since_last_labelling
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,7 +31,7 @@ private_lane :merged_prs_since_last_release do |options|
     path: "/repos/guardian/#{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
   )
 
-  UI.message("Closed PRs:\n#{closed_prs}")
+  UI.message("Closed PRs:\n#{closed_prs[:json].length()}")
 
   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|
     pr["merged_at"].nil? || # Pull request was never merged
@@ -39,6 +39,7 @@ private_lane :merged_prs_since_last_release do |options|
     pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
   }
 
+  UI.message("Merged PRs length:\n#{merged_prs_since_last_labelling.length()}")
   UI.message("Merged PRs:\n#{merged_prs_since_last_labelling}")
 
   PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,7 @@ private_lane :merged_prs_since_last_release do |options|
     server_url: "https://api.github.com",
     api_token: github_token,
     http_method: "GET",
-    path: "/repos/guardian/#{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
+    path: "/repos/guardian/#{repo}/pulls?state=closed&sort=created&direction=desc&per_page=100"
   )
 
   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,15 +13,15 @@ private_lane :merged_prs_since_last_release do |options|
 
   repo = options[:repo]
   github_token = options[:github_token]
-#   github_label = options[:github_label]
-#   earliest_datetime = options[:earliest_datetime]
-#   ensure_git_log_includes_pr = options[:ensure_git_log_includes_pr]
+  github_label = options[:github_label]
+  earliest_datetime = options[:earliest_datetime]
+  ensure_git_log_includes_pr = options[:ensure_git_log_includes_pr]
   
-#   base_branch_name = if options.has_key?(:base_branch_name)
-#     options[:base_branch_name]
-#   else
-#     "master"
-#   end
+  base_branch_name = if options.has_key?(:base_branch_name)
+    options[:base_branch_name]
+  else
+    "master"
+  end
 
   # Find all PRs that have been merged since the last beta went out
   closed_prs = github_api(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,7 @@ private_lane :merged_prs_since_last_release do |options|
 
   result = if ensure_git_log_includes_pr
     current_branch = sh("git branch --show-current")
-    sh("git checkout base_branch_name")
+    sh("git checkout %f" % base_branch_name)
     all_prs_since_last_labelling.reject { |pr|
       recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
       !recent_commits.include?(pr.merge_sha)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,55 +13,55 @@ private_lane :merged_prs_since_last_release do |options|
 
   repo = options[:repo]
   github_token = options[:github_token]
-  github_label = options[:github_label]
-  earliest_datetime = options[:earliest_datetime]
-  ensure_git_log_includes_pr = options[:ensure_git_log_includes_pr]
+#   github_label = options[:github_label]
+#   earliest_datetime = options[:earliest_datetime]
+#   ensure_git_log_includes_pr = options[:ensure_git_log_includes_pr]
   
-  base_branch_name = if options.has_key?(:base_branch_name)
-    options[:base_branch_name]
-  else
-    "master"
-  end
+#   base_branch_name = if options.has_key?(:base_branch_name)
+#     options[:base_branch_name]
+#   else
+#     "master"
+#   end
 
   # Find all PRs that have been merged since the last beta went out
   closed_prs = github_api(
     server_url: "https://api.github.com",
     api_token: github_token,
     http_method: "GET",
-    path: "/repos/guardian/#{repo}/pulls?state=closed&sort=created&direction=desc&per_page=100"
+    path: "/repos/guardian/#{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
   )
 
   UI.message("Closed PRs:\n#{closed_prs}")
 
-  merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|
-    pr["merged_at"].nil? || # Pull request was never merged
-    DateTime.parse(pr["merged_at"]) < DateTime.parse(earliest_datetime) || # Pull request was merged before the earliest date provided
-    pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
-  }
+#   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|
+#     pr["merged_at"].nil? || # Pull request was never merged
+#     DateTime.parse(pr["merged_at"]) < DateTime.parse(earliest_datetime) || # Pull request was merged before the earliest date provided
+#     pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
+#   }
 
-  UI.message("Merged PRs:\n#{merged_prs_since_last_labelling}")
+#   UI.message("Merged PRs:\n#{merged_prs_since_last_labelling}")
 
-  PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
-  all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
-    PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
-  }
+#   PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
+#   all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
+#     PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
+#   }
 
-  UI.message("All PRs:\n#{all_prs_since_last_labelling}")
+#   UI.message("All PRs:\n#{all_prs_since_last_labelling}")
 
-  #TODO: This should be the default. Why would you ever want the opposite?
-  result = if ensure_git_log_includes_pr
-    current_branch = sh("git branch --show-current")
-    sh("git fetch")
-    sh("git checkout %s" % base_branch_name)
-    recent_commits = sh("git log --format=\"%H\" -100").split("\n")
-    sh("git checkout %s" % current_branch)
+#   #TODO: This should be the default. Why would you ever want the opposite?
+#   result = if ensure_git_log_includes_pr
+#     current_branch = sh("git branch --show-current")
+#     sh("git fetch")
+#     sh("git checkout %s" % base_branch_name)
+#     recent_commits = sh("git log --format=\"%H\" -100").split("\n")
+#     sh("git checkout %s" % current_branch)
 
-    all_prs_since_last_labelling.reject { |pr|
-      !recent_commits.include?(pr.merge_sha)
-    }
-  else
-    all_prs_since_last_labelling
-  end
+#     all_prs_since_last_labelling.reject { |pr|
+#       !recent_commits.include?(pr.merge_sha)
+#     }
+#   else
+#     all_prs_since_last_labelling
+#   end
 
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,6 @@ private_lane :merged_prs_since_last_release do |options|
     "master"
   end
 
-  
   # Find all PRs that have been merged to the base branch since the last beta went out
   closed_prs = github_api(
     server_url: "https://api.github.com",
@@ -32,11 +31,15 @@ private_lane :merged_prs_since_last_release do |options|
     path: "/repos/guardian/#{repo}/pulls?state=closed&base=#{base_branch_name}&sort=created&direction=desc&per_page=100"
   )
 
+  UI.message("Closed PRs:\n#{closed_prs}")
+
   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|
     pr["merged_at"].nil? || # Pull request was never merged
     DateTime.parse(pr["merged_at"]) < DateTime.parse(earliest_datetime) || # Pull request was merged before the earliest date provided
     pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
   }
+
+  UI.message("Merged PRs:\n#{merged_prs_since_last_labelling}")
 
   PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
   all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
@@ -47,7 +50,7 @@ private_lane :merged_prs_since_last_release do |options|
 
   result = if ensure_git_log_includes_pr
     current_branch = sh("git branch --show-current")
-    sh("git fetch origin %s" % base_branch_name)
+    sh("git fetch")
     sh("git checkout %s" % base_branch_name)
     recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
     sh("git checkout %s" % current_branch)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,6 +45,7 @@ private_lane :merged_prs_since_last_release do |options|
 
   result = if ensure_git_log_includes_pr
     current_branch = sh("git branch --show-current")
+    sh("git fetch")
     sh("git checkout %s" % base_branch_name)
     all_prs_since_last_labelling.reject { |pr|
       recent_commits = sh("git log --format=\"%H\" -1000").split("\n")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,35 +33,35 @@ private_lane :merged_prs_since_last_release do |options|
 
   UI.message("Closed PRs:\n#{closed_prs}")
 
-#   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|
-#     pr["merged_at"].nil? || # Pull request was never merged
-#     DateTime.parse(pr["merged_at"]) < DateTime.parse(earliest_datetime) || # Pull request was merged before the earliest date provided
-#     pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
-#   }
+  merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|
+    pr["merged_at"].nil? || # Pull request was never merged
+    DateTime.parse(pr["merged_at"]) < DateTime.parse(earliest_datetime) || # Pull request was merged before the earliest date provided
+    pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
+  }
 
-#   UI.message("Merged PRs:\n#{merged_prs_since_last_labelling}")
+  UI.message("Merged PRs:\n#{merged_prs_since_last_labelling}")
 
-#   PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
-#   all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
-#     PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
-#   }
+  PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
+  all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
+    PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
+  }
 
-#   UI.message("All PRs:\n#{all_prs_since_last_labelling}")
+  UI.message("All PRs:\n#{all_prs_since_last_labelling}")
 
-#   #TODO: This should be the default. Why would you ever want the opposite?
-#   result = if ensure_git_log_includes_pr
-#     current_branch = sh("git branch --show-current")
-#     sh("git fetch")
-#     sh("git checkout %s" % base_branch_name)
-#     recent_commits = sh("git log --format=\"%H\" -100").split("\n")
-#     sh("git checkout %s" % current_branch)
+  #TODO: This should be the default. Why would you ever want the opposite?
+  result = if ensure_git_log_includes_pr
+    current_branch = sh("git branch --show-current")
+    sh("git fetch")
+    sh("git checkout %s" % base_branch_name)
+    recent_commits = sh("git log --format=\"%H\" -100").split("\n")
+    sh("git checkout %s" % current_branch)
 
-#     all_prs_since_last_labelling.reject { |pr|
-#       !recent_commits.include?(pr.merge_sha)
-#     }
-#   else
-#     all_prs_since_last_labelling
-#   end
+    all_prs_since_last_labelling.reject { |pr|
+      !recent_commits.include?(pr.merge_sha)
+    }
+  else
+    all_prs_since_last_labelling
+  end
 
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,14 +40,13 @@ private_lane :merged_prs_since_last_release do |options|
   }
 
   UI.message("Merged PRs length:\n#{merged_prs_since_last_labelling.length()}")
-  UI.message("Merged PRs:\n#{merged_prs_since_last_labelling}")
 
   PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
   all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
     PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
   }
 
-  UI.message("All PRs:\n#{all_prs_since_last_labelling}")
+  UI.message("All PRs length:\n#{all_prs_since_last_labelling.length()}")
 
   #TODO: This should be the default. Why would you ever want the opposite?
   result = if ensure_git_log_includes_pr

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,14 +39,10 @@ private_lane :merged_prs_since_last_release do |options|
     pr["labels"].map{|label| label["name"]}.include?(github_label) # Pull request was labelled as part of a previous release
   }
 
-  UI.message("Merged PRs:\n#{merged_prs_since_last_labelling}")
-
   PullRequest = Struct.new(:number, :title, :author, :merge_sha, :merged_at, :body)
   all_prs_since_last_labelling = merged_prs_since_last_labelling.map{ |pr|
     PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
   }
-
-  UI.message("All PRs:\n#{all_prs_since_last_labelling}")
 
   result = if ensure_git_log_includes_pr
     current_branch = sh("git branch --show-current")
@@ -55,16 +51,12 @@ private_lane :merged_prs_since_last_release do |options|
     recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
     sh("git checkout %s" % current_branch)
 
-    UI.message("Recent commits:\n#{recent_commits}")
-
     all_prs_since_last_labelling.reject { |pr|
       !recent_commits.include?(pr.merge_sha)
     }
   else
     all_prs_since_last_labelling
   end
-
-  UI.message("Result:\n#{result}")
 
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,6 +43,8 @@ private_lane :merged_prs_since_last_release do |options|
     PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
   }
 
+  UI.message("All PRs:\n#{all_prs_since_last_labelling}")
+
   result = if ensure_git_log_includes_pr
     current_branch = sh("git branch --show-current")
     sh("git fetch origin %s" % base_branch_name)
@@ -50,12 +52,16 @@ private_lane :merged_prs_since_last_release do |options|
     recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
     sh("git checkout %s" % current_branch)
 
+    UI.message("Recent commits:\n#{recent_commits}")
+
     all_prs_since_last_labelling.reject { |pr|
       !recent_commits.include?(pr.merge_sha)
     }
   else
     all_prs_since_last_labelling
   end
+
+  UI.message("Result:\n#{result}")
 
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,7 @@ private_lane :merged_prs_since_last_release do |options|
     server_url: "https://api.github.com",
     api_token: github_token,
     http_method: "GET",
-    path: "/repos/guardian/#{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
+    path: "/repos/guardian/#{repo}/pulls?state=closed&sort=created&direction=desc&per_page=100"
   )
 
   UI.message("Closed PRs:\n#{closed_prs}")


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
We would like to be able to run this lane on a tag, or branch other than the default. To allow this, we should fetch all merged PRs (regardless of their base branch), and then filter by only those commits that have ended up in the base_branch history.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
On iOS I have created [an action](https://github.com/guardian/ios-live/actions/workflows/sl-test.yml) which calls this - you can see that if you had it do the same thing previously, the list of PRs would be empty.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
iOS release notes/PR links will appear in the releases channel again.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
I believe that the first release after this is merged will result in any PRs that were merged into a branch other than master/main, being marked as `released to beta`, and included in the release notes. This should be a one-off occurrence. We can manually update the release channel to clarify.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
N/A