### PR TITLE
Update git command to read current branch name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,7 +42,7 @@ private_lane :merged_prs_since_last_release do |options|
     PullRequest.new(pr["number"], pr["title"], pr["user"]["login"], pr["merge_commit_sha"], pr["merged_at"], pr["body"])
   }
 
-  current_branch = sh("git branch --show-current")
+  current_branch = sh("git rev-parse --abbrev-ref HEAD")
   sh("git fetch")
   sh("git checkout %s" % base_branch_name)
   recent_commits = sh("git log --format=\"%H\" -100").split("\n")


### PR DESCRIPTION
## What does this change?

This PR updates the git command to read current branch name. 

PR #15 introduced `git branch --show-current`, but it only works on git `v2.22+`. The git version in TeamCity/AWS VMs used by us is lower than this, so the command throws and the beta build process for Android fails.

This PR replaces it with the older, but worse named, `git rev-parse --abbrev-ref HEAD`.

## How to test

The good way:

1. In your client repo's fastlane file, add branch name for this PR: 
   ```
   import_from_git(url:"https://github.com/guardian/cross-platform-fastlane.git", path:"fastlane/Fastfile", branch: "fix-git-get-current-branch")
   ```
2. Create a personal access token in Github, and add it to your env:
   ```
   export GITHUB_TOKEN="abcde..."
   ```
3. Run `bundle exec fastlane get_release_metadata`
4. Confirm that the command finishes successfully without throwing.
5. Optionally add some logging commands to the `get_release_metadata` lane in the client fastlane to log the merged PRs being returned.

The bad, easy way:
1. Wait for this to merge, then create a beta.

## How can we measure success?

The beta release processes for both iOS and Android should successfully complete.

