### PR TITLE
Support GHA's `GITHUB_TOKEN`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,7 @@ private_lane :merged_prs_since_last_release do |options|
   # Don't use `sort=updated` here, because some changes (e.g. branch names, labelling) may mass-update very old PRs.
   closed_prs = github_api(
     server_url: "https://api.github.com",
-    api_token: github_token,
+    api_bearer: github_token,
     http_method: "GET",
     path: "/repos/guardian/#{repo}/pulls?state=closed&sort=created&direction=desc&per_page=100"
   )
@@ -113,14 +113,14 @@ private_lane :update_pr_after_release do |options|
   UI.message("Marking PR #{pr_number} as released to #{environment}")
   github_api(
     server_url: "https://api.github.com",
-    api_token: github_token,
+    api_bearer: github_token,
     http_method: "POST",
     path: "/repos/guardian/#{repo}/issues/#{pr_number}/labels",
     body: { labels: ["released_to_#{environment}"] }
   )
   github_api(
     server_url: "https://api.github.com",
-    api_token: github_token,
+    api_bearer: github_token,
     http_method: "POST",
     path: "/repos/guardian/#{repo}/issues/#{pr_number}/comments",
     body: { body: "@#{pr_author}: these changes were released to #{environment} in version `#{full_version}`." }
@@ -140,14 +140,14 @@ private_lane :update_pr_after_beta_release do |options|
   UI.message("Marking PR #{pr_number} as released to beta")
   github_api(
     server_url: "https://api.github.com",
-    api_token: github_token,
+    api_bearer: github_token,
     http_method: "POST",
     path: "/repos/guardian/#{repo}/issues/#{pr_number}/labels",
     body: { labels: ["released_to_beta"] }
   )
   github_api(
     server_url: "https://api.github.com",
-    api_token: github_token,
+    api_bearer: github_token,
     http_method: "POST",
     path: "/repos/guardian/#{repo}/issues/#{pr_number}/comments",
     body: { body: "@#{pr_author}: these changes were released to beta in version `#{build_number}`." }
@@ -165,7 +165,7 @@ private_lane :add_tag do |options|
   UI.message("Adding tag #{tag_name} to commit #{commit_sha} for the #{repo} repo...")
   github_api(
     server_url: "https://api.github.com",
-    api_token: github_token,
+    api_bearer: github_token,
     http_method: "POST",
     path: "/repos/guardian/#{repo}/git/refs",
     body: { "ref": "refs/tags/#{tag_name}", "sha": "#{commit_sha}" }
@@ -215,7 +215,7 @@ private_lane :calculate_templates_release_times do |options|
 
   tagsForTemplatesRepo = github_api(
     server_url: "https://api.github.com",
-    api_token: github_token,
+    api_bearer: github_token,
     http_method: "GET",
     path: "/repos/guardian/#{templates_repo}/tags"
   )
@@ -254,7 +254,7 @@ private_lane :calculate_templates_release_times do |options|
       UI.message("Marking PR #{pr_with_version.number} as released to production (on #{platform})")
       github_api(
         server_url: "https://api.github.com",
-        api_token: github_token,
+        api_bearer: github_token,
         http_method: "POST",
         path: "/repos/guardian/#{templates_repo}/issues/#{pr_with_version.number}}/labels",
         body: { labels: ["released_to_prod_#{platform}"] }


### PR DESCRIPTION
## What does this change?

This switches to using `api_bearer` instead of `api_token`. From I've tested, both personal access tokens (like the ones we use) and gha's `GITHUB_TOKEN` work when using `api_bearer`

For reference:
* api_token Personal API Token for GitHub 
* api_bearer Use a Bearer authorization token. Usually generated by Github Apps, e.g. GitHub Actions GITHUB_TOKEN environment variable

Blocked by https://github.com/guardian/android-news-app/pull/7798
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Like so
```
import_from_git(
  url: "https://github.com/guardian/cross-platform-fastlane.git", # The URL of the repository to import the Fastfile from.
  branch: "github-token", # The branch to checkout on the repository.
  path: "fastlane/Fastfile" # The path of the Fastfile in the repository.
)
```

* Compatibility should not be broken with existing PAT
* Should within GHA using `GITHUB_TOKEN`