### PR TITLE
Increase search history to 1000

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,7 @@ private_lane :merged_prs_since_last_release do |options|
   current_branch = sh("git rev-parse --abbrev-ref HEAD")
   sh("git fetch")
   sh("git checkout %s" % base_branch_name)
-  recent_commits = sh("git log --format=\"%H\" -100").split("\n")
+  recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
   sh("git checkout %s" % current_branch)
 
   all_prs_since_last_labelling.reject { |pr|


### PR DESCRIPTION
## What does this change?

Looks at the last 1000 commits in main, instead of just 100.

This is necessary to support android release notes. Typically, android release have around 350 commits.

## How to test

Like so
```
import_from_git(
  url: "https://github.com/guardian/cross-platform-fastlane.git", # The URL of the repository to import the Fastfile from.
  branch: "ja-longer-history", # The branch to checkout on the repository.
  path: "fastlane/Fastfile" # The path of the Fastfile in the repository.
)

Android release notes should be generated with all the relevant PRs!
## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
