### PR TITLE
Avoid printing 1000 commits in the build log

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,7 @@ private_lane :merged_prs_since_last_release do |options|
   current_branch = sh("git rev-parse --abbrev-ref HEAD")
   sh("git fetch")
   sh("git checkout %s" % base_branch_name)
-  recent_commits = sh("git log --format=\"%H\" -1000").split("\n")
+  recent_commits = sh("git log --format=\"%H\" -1000", log:false).split("\n")
   sh("git checkout %s" % current_branch)
 
   all_prs_since_last_labelling.reject { |pr|


### PR DESCRIPTION
## What does this change?

This is a follow up to #20, which works as expected (1000 commits are now being considered for the release notes), but the commits ids are actually being printed in log output. All 1000 of them.

This PR hides the log output for this command.