### PR TITLE
Hide very long JSON responses from fastlane log output

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,6 +30,8 @@ private_lane :merged_prs_since_last_release do |options|
     http_method: "GET",
     path: "/repos/guardian/#{repo}/pulls?state=closed&sort=created&direction=desc&per_page=100"
   )
+  lane_context.delete(SharedValues::GITHUB_API_RESPONSE)
+  lane_context.delete(SharedValues::GITHUB_API_JSON)
 
   merged_prs_since_last_labelling = closed_prs[:json].reject{ |pr|
     pr["merged_at"].nil? || # Pull request was never merged

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -219,6 +219,8 @@ private_lane :calculate_templates_release_times do |options|
     http_method: "GET",
     path: "/repos/guardian/#{templates_repo}/tags"
   )
+  lane_context.delete(SharedValues::GITHUB_API_RESPONSE)
+  lane_context.delete(SharedValues::GITHUB_API_JSON)
 
   tags = tagsForTemplatesRepo[:json].map { |tag| Tag.new(tag["commit"]["sha"], tag["name"]) }
 


### PR DESCRIPTION
## What does this change?

So fastlane does this thing where it prints tables. On successful execution it prints a table called "fastlane summary" 

![Screenshot 2022-10-06 at 16 15 50](https://user-images.githubusercontent.com/1672034/194351458-a935daea-6f02-4441-8403-e56e64951057.png)

On error, it will print an additional table called "Lane Context", which prints the value of a few variables with the intention of facilitating debugging the error

![Screenshot 2022-10-06 at 16 15 01](https://user-images.githubusercontent.com/1672034/194351249-2514141e-65f5-47b3-88bc-dff4b602096f.png)

I've become aware that sometimes this table is gigantic in size and completely breaks the GHA interface. Like so:

![Screenshot 2022-10-06 at 16 22 48](https://user-images.githubusercontent.com/1672034/194353258-0f3f3c6c-e5ce-4ab3-935a-2bb6701316bf.png)

I've traced it back to [this github_api call](https://github.com/guardian/cross-platform-fastlane/blob/63d0dd437cec2131087033314325875abb2a7fcb/fastlane/Fastfile#L27), which fetches the 100 most recent PRs. `github_api` "publishes" [these 3 variables, ](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/github_api.rb#L56)which include the gigant JSON it gets back.

```
GITHUB_API_STATUS_CODE
GITHUB_API_RESPONSE
GITHUB_API_JSON
```

It's these the response and json variables being printed that break the table. They're much too enormous/

Given there's no option to configure `github_api` not to do this, this PR works around that by removing them from the "lane context" dictionary (which is the thing that gets printed in the table) after the call. This leaves only the status code, which prints fine.

![Screenshot 2022-10-06 at 16 28 11](https://user-images.githubusercontent.com/1672034/194354614-9e9bd606-0805-4e5e-b427-dc67b1dad665.png)

