### PR TITLE
Make it safe to tag PRs in batch

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -111,6 +111,7 @@ private_lane :update_pr_after_release do |options|
   environment = options[:environment]
 
   UI.message("Marking PR #{pr_number} as released to #{environment}")
+  sleep(1)
   github_api(
     server_url: "https://api.github.com",
     api_token: github_token,
@@ -118,6 +119,7 @@ private_lane :update_pr_after_release do |options|
     path: "/repos/guardian/#{repo}/issues/#{pr_number}/labels",
     body: { labels: ["released_to_#{environment}"] }
   )
+  sleep(1)
   github_api(
     server_url: "https://api.github.com",
     api_token: github_token,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -101,6 +101,10 @@ private_lane :prepare_release_notes do |options|
 
 end
 
+# This lane has sleep(1) to be a good citizen of the github API and avoid
+# secondary API rate limits. From the documentation:
+# > If you're making a large number of POST [...] requests for a single
+# > user or client ID, wait at least one second between each request.
 private_lane :update_pr_after_release do |options|
 
   repo = options[:repo]


### PR DESCRIPTION
## What does this change?

We've been getting hit by secondary API rate limits when tagging large numbers of PRs on the android project
![Screenshot 2022-10-13 at 13 35 56](https://user-images.githubusercontent.com/1672034/195597595-9557c507-a116-4372-9e5d-73d4c1600903.png)

Whereas the auth token itself is allowed 1000s of API calls per hour, some API endpoints will impose a another, "secondary", limit on top of that. 

According to [the documentation](https://docs.github.com/en/rest/guides/best-practices-for-integrators) on dealing with secondary API rate limits.

> If you're making a large number of POST, PATCH, PUT, or DELETE requests for a single user or client ID, wait at least one second between each request.
